### PR TITLE
Makes framework guarantee it's safe for extension use

### DIFF
--- a/FloatLabelRow.xcodeproj/project.pbxproj
+++ b/FloatLabelRow.xcodeproj/project.pbxproj
@@ -362,6 +362,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 750A4210146D258B96749891 /* Pods-FloatLabelRow.debug.xcconfig */;
 			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				DEFINES_MODULE = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;
@@ -385,6 +386,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 62D452821D7ACA8A74B470D9 /* Pods-FloatLabelRow.release.xcconfig */;
 			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				DEFINES_MODULE = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;


### PR DESCRIPTION
Hi! Thanks for a great component!

We're using this inside another framework which is used in an extension so it would be great if the float label component could guarantee it's safe for extension use, just as Eureka does.

Also, you might want to add a `master` branch :)