### PR TITLE
Make FloatLabelRow conform to using `displayValueFor`

### DIFF
--- a/Sources/FloatLabelRow.swift
+++ b/Sources/FloatLabelRow.swift
@@ -130,7 +130,7 @@ open class _FloatLabelCell<T>: Cell<T>, UITextFieldDelegate, TextFieldCell where
         if let formatter = (row as? FormatterConformance)?.formatter, useFormatter {
             return textField?.isFirstResponder == true ? formatter.editingString(for: v) : formatter.string(for: v)
         }
-        return String(describing: v)
+        return row.displayValueFor?(v) ?? String(describing: v)
     }
     
     //MARK: TextFieldDelegate


### PR DESCRIPTION
... making it work like other rows where you can return another displayed value than what's saved in the row. This fixes an issue where if you had a formatter, the row would still display the raw value when the row was initially selected.