### PR TITLE
Support tintColor better in addition to custom active text colors

### DIFF
--- a/Sources/FloatLabelTextField.swift
+++ b/Sources/FloatLabelTextField.swift
@@ -28,6 +28,7 @@ import UIKit
     
     let animationDuration = 0.3
     var title = UILabel()
+    var overrideTintColorActiveColor = false
     
     // MARK:- Properties
     override public var accessibilityLabel:String! {
@@ -82,10 +83,26 @@ import UIKit
         }
     }
     
-    @IBInspectable var titleActiveTextColour:UIColor! {
+    @IBInspectable var titleActiveTextColour:UIColor? {
+        didSet {
+            overrideTintColorActiveColor = (titleActiveTextColour != nil)
+            
+            if overrideTintColorActiveColor {
+                titleCustomActiveTextColour = titleActiveTextColour
+            } else {
+                titleCustomActiveTextColour = tintColor
+            }
+        }
+    }
+    
+    /// The actual backing colour for the text field's active state. This is private
+    ///  in order to facilitate switching between a custom set active color using
+    ///  `titleActiveTextColour` and the default which is to respect and mirror
+    ///  the UIView.tintColor property.
+    private var titleCustomActiveTextColour: UIColor? {
         didSet {
             if isFirstResponder {
-                title.textColor = titleActiveTextColour
+                title.textColor = titleCustomActiveTextColour
             }
         }
     }
@@ -107,7 +124,7 @@ import UIKit
         setTitlePositionForTextAlignment()
         let isResp = isFirstResponder
         if isResp && !(text?.isEmpty ?? true) {
-            title.textColor = titleActiveTextColour
+            title.textColor = titleCustomActiveTextColour
         } else {
             title.textColor = titleTextColour
         }
@@ -119,6 +136,12 @@ import UIKit
             // Show
             showTitle(isResp)
         }
+    }
+    
+    override public func tintColorDidChange() {
+        super.tintColorDidChange()
+        
+        self.titleCustomActiveTextColour = tintColor
     }
     
     override public func textRect(forBounds bounds:CGRect) -> CGRect {
@@ -154,7 +177,7 @@ import UIKit
     // MARK:- Private Methods
     private func setup() {
         borderStyle = UITextBorderStyle.none
-        titleActiveTextColour = tintColor
+        titleCustomActiveTextColour = tintColor
         // Set up title label
         title.alpha = 0.0
         title.font = titleFont


### PR DESCRIPTION
This fixes an issue with `.tintColor` not always being applied or reflecting changes in `tintColor` when no other color has been set.

Changes proposed in this request:
* Support `tintColor` changes through overriding `tintColorDidChange()`
* Support custom active label color when `tintColor` changes (don't use tintColor)

Leveraging `tintColorDidChange()` makes `tintColor` utilization more robust since `tintColor` has not always been set by the time `setup()` is called. This would depend on if the Eureka row/cell creation was being performed before or after it is already in the view hierarchy. Now `tintColor` will always be applied correctly regardless of order of operations in cell setup/creation.

For these code changes, the tint color is still the default active label color and will track changes in this property whenever they are updated. Setting a custom color through IB for this label's active state is also supported and will override the `tintColor` regardless of subsequent `tintColor` changes.

This changeset also appears to do much of what #7 set out to do without having to make the color properties public and based on the implementation details, may have been how the active text color was meant to be changed from the beginning.

